### PR TITLE
Fixed broken link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ https://github.com/danielhenrymantilla/higher-kinded-types.rs/actions)
 
 See the documentation of the <code>[ForLifetime]</code> trait for more info.
 
-[ForLifetime]: https://docs.rs/higher-kinded-types/0.2.0-rc1/higher-kinded-types/trait.ForLifetime.html
+[ForLifetime]: https://docs.rs/higher-kinded-types/0.2.0-rc1/higher_kinded_types/trait.ForLifetime.html
 
 <!-- Templated by `cargo-generate` using https://github.com/danielhenrymantilla/proc-macro-template -->


### PR DESCRIPTION
PR fixing the broken link discovered by vague in [this](https://users.rust-lang.org/t/how-to-use-hrtbs-to-specify-lifetime-of-return-value/105322/7?u=jofas) URLO reply. Recently I [revisited](https://users.rust-lang.org/t/doc-include-str-readme-md-and-links-to-crate-items/106199/3?u=jofas) this repo and saw the link was still broken! So I thought I'd make myself useful and fix it. And yes, I do see myself as an invaluable contributor to open source :sunglasses: 

---

![When your PR that fixed a small typo is accepted and you see your name among the contributors](https://camo.githubusercontent.com/ae3ac990f18f2f08965a3341c2ab5a5d14a16991564e4d0fb6ff141906e739f7/68747470733a2f2f692e726564642e69742f39356438783033656f377634312e706e67)